### PR TITLE
Đặt lại trạng thái viewer và báo node trống

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,17 @@
     const typeOf = (v)=> v===null?'null':Array.isArray(v)?'array':typeof v;
     function formatPrimitive(v){ const t=typeOf(v); const span=document.createElement('span'); span.className=`primitive ${t}`; span.textContent=t==='string'?`"${v}"`:String(v); return span; }
     const escapeHtml = (s)=> String(s).replace(/[&<>\"]/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;"}[c]));
+
+    // Tạo một hàng ghi chú khi node trống
+    function makeEmptyRow(msg='Không có dữ liệu'){
+      const li=document.createElement('li');
+      const row=document.createElement('div'); row.className='node leaf';
+      const spacer=document.createElement('span'); spacer.className='spacer'; row.appendChild(spacer);
+      const label=document.createElement('span'); label.className='label'; label.innerHTML=`<em>${msg}</em>`;
+      row.appendChild(label);
+      li.appendChild(row);
+      return li;
+    }
     
     // Helper function to get value by JSONPath
     function getValueByPath(path) {
@@ -221,7 +232,7 @@
       // Label
       const label = document.createElement('span'); label.className='label';
       const len = t==='array' ? value.length : (t==='object'? Object.keys(value).length : 0);
-      const meta = isContainer ? `${t==='array'?'[ ]':'{ }'} • ${len} mục` : '';
+      const meta = isContainer ? `${t==='array'?'[ ]':'{ }'} • ${len} mục${len===0?' (trống)':''}` : '';
       label.innerHTML = `<span class="key">${escapeHtml(key)}</span>${isContainer?`<span class="meta">: ${meta}</span>`:''}<span class="type">${t}</span>${!isContainer?` : ${formatPrimitive(value).outerHTML}`:''}`;
 
       // Copy buttons
@@ -242,7 +253,17 @@
         const children = document.createElement('ul'); children.hidden = !expandState.has(path);
         if(!children.hidden) row.querySelector('.caret').classList.add('open');
         let injected = false;
-        function inject(){ if(injected) return; injected=true; if(t==='array'){ value.forEach((v,i)=> children.appendChild(makeNode(String(i), v, `${path}[${i}]`))); } else { Object.keys(value).forEach(k=> children.appendChild(makeNode(k, value[k], `${path}.${k}`))); } }
+        function inject(){
+          if(injected) return; injected=true;
+          if(t==='array'){
+            if(value.length===0){ children.appendChild(makeEmptyRow()); }
+            else{ value.forEach((v,i)=> children.appendChild(makeNode(String(i), v, `${path}[${i}]`))); }
+          } else {
+            const keys=Object.keys(value);
+            if(keys.length===0){ children.appendChild(makeEmptyRow()); }
+            else{ keys.forEach(k=> children.appendChild(makeNode(k, value[k], `${path}.${k}`))); }
+          }
+        }
         let isToggling = false;
         function toggle(){ 
           if (isToggling) return; // Chặn click nhanh liên tiếp
@@ -460,7 +481,22 @@
     $('#btnSample').addEventListener('click', ()=>{ const sample={ success:true, custom_param:{ ModelState:"2", RequestId:"abc-123" }, data:{ order:{ id:101, code:"SO-000101", created:"2025-08-11", total:123456.78, items:[ {sku:"A1", qty:1, price:45678}, {sku:"B2", qty:2, price:38900} ], customer:{ id:9, name:"Nguyen Van A", phones:["0901...","0283..."], address:{ city:"HCMC", ward:"P.5" } } } } }; input.value = pretty(sample); parseInput(); });
 
     input.addEventListener('input', debounce(parseInput, 250));
-    function parseInput(){ const obj = safeParse(input.value); if (obj.__error){ currentJson=null; renderTree(treeWrap, obj); return; } currentJson=obj; renderTree(treeWrap, currentJson); }
+    function parseInput(){
+      const obj = safeParse(input.value);
+      expandState = new Set();
+      selectedNode = null;
+      searchHits = [];
+      hitIndex = -1;
+      searchInput.value = '';
+      searchStatus.textContent = '';
+      if (obj.__error){
+        currentJson = null;
+        renderTree(treeWrap, obj);
+        return;
+      }
+      currentJson = obj;
+      renderTree(treeWrap, currentJson);
+    }
 
     // Search
     searchInput.addEventListener('input', debounce(()=>doSearch(searchInput.value), 200));


### PR DESCRIPTION
## Tóm tắt
- Đặt lại trạng thái mở/đóng, lựa chọn và tìm kiếm khi dán JSON mới
- Hiển thị ghi chú "Không có dữ liệu" cho node không có con

## Kiểm thử
- `npm test` *(lỗi: không tìm thấy package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a95057ec832c9744d59422975fc4